### PR TITLE
Fix skills directory path

### DIFF
--- a/skills/meta/writing-skills/SKILL.md
+++ b/skills/meta/writing-skills/SKILL.md
@@ -12,7 +12,7 @@ languages: all
 
 **Writing skills IS Test-Driven Development applied to process documentation.**
 
-**Skills are written to `${SUPERPOWERS_SKILLS_ROOT}/skills/` (cloned to `~/.config/superpowers/skills/`).** You edit skills in your local branch of this repository.
+**Skills are written to `${SUPERPOWERS_SKILLS_ROOT}` (cloned to `~/.config/superpowers/skills/`).** You edit skills in your local branch of this repository.
 
 You write test cases (pressure scenarios with subagents), watch them fail (baseline behavior), write the skill (documentation), watch tests pass (agents comply), and refactor (close loopholes).
 
@@ -71,10 +71,10 @@ API docs, syntax guides, tool documentation (office docs)
 
 ## Directory Structure
 
-**All skills are in the skills repository at `${SUPERPOWERS_SKILLS_ROOT}/skills/`:**
+**All skills are in the skills repository at `${SUPERPOWERS_SKILLS_ROOT}`:**
 
 ```
-${SUPERPOWERS_SKILLS_ROOT}/skills/
+${SUPERPOWERS_SKILLS_ROOT}
   skill-name/
     SKILL.md              # Main reference (required)
     supporting-file.*     # Only if needed
@@ -248,7 +248,7 @@ Use path format without `@` prefix or `/SKILL.md` suffix:
 
 **Why no @ links:** `@` syntax force-loads files immediately, consuming 200k+ context before you need them.
 
-**To read a skill reference:** Use Read tool on `${SUPERPOWERS_SKILLS_ROOT}/skills/category/skill-name/SKILL.md`
+**To read a skill reference:** Use Read tool on `${SUPERPOWERS_SKILLS_ROOT}/category/skill-name/SKILL.md`
 
 ## Flowchart Usage
 


### PR DESCRIPTION
Related to https://github.com/obra/superpowers/issues/8

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated path references to use the root skills directory, removing the redundant skills/ subpath.
  * Revised directory structure examples to reflect the new base path for skills.
  * Adjusted link and reference text for SKILL.md locations to match the updated layout.
  * Clarifications improve consistency across docs, reduce confusion when locating skills, and align examples and instructions with the current directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->