### PR TITLE
feat: project-local skills

### DIFF
--- a/skills/meta/writing-skills/SKILL.md
+++ b/skills/meta/writing-skills/SKILL.md
@@ -47,16 +47,21 @@ The entire skill creation process follows RED-GREEN-REFACTOR.
 
 ## When to Create a Skill
 
-**Create when:**
+**Create a global skill when:**
 - Technique wasn't intuitively obvious to you
 - You'd reference this again across projects
 - Pattern applies broadly (not project-specific)
 - Others would benefit
 
-**Don't create for:**
+**Create a project skill when:**
+- Technique is specific to this project/codebase
+- Pattern only applies within this team or repository
+- Project-specific conventions and workflows
+- Team wants to version-control shared techniques
+
+**Don't create a skill for:**
 - One-off solutions
 - Standard practices well-documented elsewhere
-- Project-specific conventions (put in CLAUDE.md)
 
 ## Skill Types
 
@@ -71,7 +76,7 @@ API docs, syntax guides, tool documentation (office docs)
 
 ## Directory Structure
 
-**All skills are in the skills repository at `${SUPERPOWERS_SKILLS_ROOT}`:**
+**Global skills are in the skills repository at `${SUPERPOWERS_SKILLS_ROOT}`:**
 
 ```
 ${SUPERPOWERS_SKILLS_ROOT}
@@ -80,7 +85,20 @@ ${SUPERPOWERS_SKILLS_ROOT}
     supporting-file.*     # Only if needed
 ```
 
-**Flat namespace** - all skills in one searchable location
+**Project skills are in your project's `.superpowers/skills/` directory:**
+
+```
+.superpowers/skills/
+  skill-name/
+    SKILL.md              # Main reference (required)
+    supporting-file.*     # Only if needed
+```
+
+**Key differences:**
+
+- **Global skills**: Synced from `obra/superpowers-skills`, shared across all projects
+- **Project skills**: Committed to your project repo, shared with team via version control
+- **Shadowing**: Project skills override global skills with the same path
 
 **Separate files for:**
 1. **Heavy reference** (100+ lines) - API docs, comprehensive syntax

--- a/skills/using-skills/SKILL.md
+++ b/skills/using-skills/SKILL.md
@@ -2,7 +2,7 @@
 name: Getting Started with Skills
 description: Skills wiki intro - mandatory workflows, search tool, brainstorming triggers
 when_to_use: when starting any conversation
-version: 4.0.2
+version: 4.1.0
 ---
 
 # Getting Started with Skills

--- a/skills/using-skills/SKILL.md
+++ b/skills/using-skills/SKILL.md
@@ -100,3 +100,20 @@ Your human partner's specific instructions describe WHAT to do, not HOW.
 **Skill has checklist?** TodoWrite for every item.
 
 **Finding a relevant skill = mandatory to read and use it. Not optional.**
+
+## Skill Locations
+
+Skills are discovered with shadowing precedence:
+
+**1. Project skills** (highest precedence)
+- Location: `.superpowers/skills/` in current directory
+- Purpose: Project-specific patterns and conventions
+- Shadows: Global skills with same path
+- Example: `.superpowers/skills/testing/project-tests/SKILL.md`
+
+**2. Global skills** (base location)
+- Location: `~/.config/superpowers/skills/skills/`
+- Purpose: Your personal library of skills
+- Synced from upstream: obra/superpowers-skills repository
+
+Both `find-skills` and `skill-run` automatically search both locations in precedence order.

--- a/skills/using-skills/find-skills
+++ b/skills/using-skills/find-skills
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # find-skills - Find and list skills with when_to_use guidance
 # Shows all skills by default, filters by pattern if provided
+# Searches project skills (.superpowers/skills), then global
 
 set -euo pipefail
 
 # Determine directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SKILLS_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GLOBAL_SKILLS_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 SUPERPOWERS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/superpowers"
 LOG_FILE="${SUPERPOWERS_DIR}/search-log.jsonl"
@@ -29,10 +30,13 @@ EXAMPLES:
 OUTPUT:
   Each line shows: Use skill-path/SKILL.md when [trigger]
   Paths include /SKILL.md for direct use with Read tool
+  Project skills from .superpowers/skills shown first
+  Global skills shown last
 
 SEARCH:
   Searches both skill content AND path names.
-  Skills location: ~/.config/superpowers/skills/
+  Project skills: .superpowers/skills/ in current directory
+  Global skills: ~/.config/superpowers/skills/skills/
 EOF
     exit 0
 fi
@@ -56,6 +60,7 @@ get_skill_path() {
 
 # Collect all matching skills
 results=()
+seen_skills_list=""
 
 # If pattern provided, log the search
 if [[ -n "$PATTERN" ]]; then
@@ -63,23 +68,50 @@ if [[ -n "$PATTERN" ]]; then
     echo "{\"timestamp\":\"$timestamp\",\"query\":\"$PATTERN\"}" >> "$LOG_FILE" 2>/dev/null || true
 fi
 
-# Search skills directory
+# Search current directory .superpowers/skills first
+PROJECT_SKILLS_DIR="$PWD/.superpowers/skills"
+if [[ -d "$PROJECT_SKILLS_DIR" ]]; then
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+
+        skill_path=$(get_skill_path "$file" "$PROJECT_SKILLS_DIR")
+        when_to_use=$(get_when_to_use "$file")
+
+        seen_skills_list="${seen_skills_list}${skill_path}"$'\n'
+        results+=("$skill_path|$when_to_use")
+    done < <(
+        if [[ -n "$PATTERN" ]]; then
+            {
+                grep -E -r "$PATTERN" "$PROJECT_SKILLS_DIR/" --include="SKILL.md" -l 2>/dev/null || true
+                find "$PROJECT_SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null | grep -E "$PATTERN" 2>/dev/null || true
+            } | sort -u
+        else
+            find "$PROJECT_SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null || true
+        fi
+    )
+fi
+
+# Search global skills directory (skip if shadowed)
 while IFS= read -r file; do
     [[ -z "$file" ]] && continue
 
-    skill_path=$(get_skill_path "$file" "$SKILLS_DIR")
+    skill_path=$(get_skill_path "$file" "$GLOBAL_SKILLS_DIR")
+
+    # Skip if shadowed by project skills
+    if [[ -n "$seen_skills_list" ]]; then
+        echo "$seen_skills_list" | grep -q "^${skill_path}$" && continue
+    fi
+
     when_to_use=$(get_when_to_use "$file")
     results+=("$skill_path|$when_to_use")
 done < <(
     if [[ -n "$PATTERN" ]]; then
-        # Pattern mode: search content and paths
         {
-            grep -E -r -- "$PATTERN" "$SKILLS_DIR/" --include="SKILL.md" -l 2>/dev/null || true
-            find "$SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null | grep -E -- "$PATTERN" 2>/dev/null || true
+            grep -E -r -- "$PATTERN" "$GLOBAL_SKILLS_DIR/" --include="SKILL.md" -l 2>/dev/null || true
+            find "$GLOBAL_SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null | grep -E -- "$PATTERN" 2>/dev/null || true
         } | sort -u
     else
-        # Show all
-        find "$SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null || true
+        find "$GLOBAL_SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null || true
     fi
 )
 

--- a/skills/using-skills/skill-run
+++ b/skills/using-skills/skill-run
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Generic runner for skill scripts
+# Searches project skills (.superpowers), then global
 #
 # Usage: scripts/skill-run <skill-relative-path> [args...]
 # Example: scripts/skill-run skills/collaboration/remembering-conversations/tool/search-conversations "query"
@@ -10,14 +11,15 @@ if [[ $# -eq 0 ]]; then
     cat <<'EOF'
 Usage: scripts/skill-run <skill-relative-path> [args...]
 
-Runs scripts from skills directory.
+Runs scripts from skills, checking project first, then global.
 
 Examples:
   scripts/skill-run skills/collaboration/remembering-conversations/tool/search-conversations "query"
   scripts/skill-run skills/collaboration/remembering-conversations/tool/index-conversations --cleanup
 
-The script will be found at:
-  ${SUPERPOWERS_SKILLS_ROOT}/<skill-relative-path>
+The script will be found at (in priority order):
+  1. .superpowers/<skill-relative-path> (project-local, if exists)
+  2. ${SUPERPOWERS_SKILLS_ROOT}/<skill-relative-path> (global skills)
 EOF
     exit 1
 fi
@@ -28,17 +30,24 @@ shift  # Remove script path from args, leaving remaining args
 
 # Determine directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SKILLS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GLOBAL_SKILLS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# Try to run the script
-SCRIPT="${SKILLS_ROOT}/${SCRIPT_PATH}"
-if [[ -x "$SCRIPT" ]]; then
-    exec "$SCRIPT" "$@"
+# Try project-local first
+PROJECT_SCRIPT="$PWD/.superpowers/${SCRIPT_PATH}"
+if [[ -x "$PROJECT_SCRIPT" ]]; then
+    exec "$PROJECT_SCRIPT" "$@"
+fi
+
+# Fall back to global
+GLOBAL_SCRIPT="${GLOBAL_SKILLS_ROOT}/${SCRIPT_PATH}"
+if [[ -x "$GLOBAL_SCRIPT" ]]; then
+    exec "$GLOBAL_SCRIPT" "$@"
 fi
 
 # Not found
 echo "Error: Script not found: $SCRIPT_PATH" >&2
 echo "" >&2
 echo "Searched:" >&2
-echo "  $SCRIPT" >&2
+echo "  $PROJECT_SCRIPT (project)" >&2
+echo "  $GLOBAL_SCRIPT (global)" >&2
 exit 1


### PR DESCRIPTION
# Add support for project-local skills

## Motivation and Context

This change enables teams to define project-specific skills that live in `.superpowers/skills/` within their codebase, allowing teams to:
- Document project-specific patterns and conventions
- Customize existing skills for their project's needs
- Share skills through version control with the rest of the team
- Override global skills with project-specific variants

The shadowing system provides clear precedence: project skills in `.superpowers/skills/` shadow global skills at `~/.config/superpowers/skills/skills/`.

## Implementation Details

**Key changes:**

1. **Project skills directory**: Both `find-skills` and `skill-run` now check for `.superpowers/skills/` in the
current directory before falling back to global skills

2. **Shadowing precedence**:
   - `.superpowers/skills/test/SKILL.md` shadows `~/.config/superpowers/skills/skills/test/SKILL.md`
   - Project skills always take priority over global skills

3. **Updated help text**: Both scripts now document the two-tier search behavior

4. **Documentation updates**:
   - `skills/using-skills/SKILL.md` updated with "Skill Locations" section
   - `skills/meta/writing-skills/SKILL.md` updated to distinguish global vs project skills

## How Has This Been Tested?

- [x] `find-skills` correctly discovers skills from project and global locations
- [x] Project skills properly shadow global skills with matching paths
- [x] `skill-run` executes scripts with correct precedence order
- [x] Backward compatibility: existing workflows continue unchanged when no `.superpowers/skills/` exists

## Breaking Changes

None. This is a fully backward-compatible addition:
- Existing workflows continue to function identically
- No changes required to existing skills
- Project skills are opt-in (only activated when `.superpowers/skills/` exists)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Files Modified

### Scripts
- `skills/using-skills/find-skills`: Added project skills search before global
- `skills/using-skills/skill-run`: Added project skills search before global

### Documentation
- `skills/using-skills/SKILL.md`: Added "Skill Locations" section documenting project vs global skills
- `skills/meta/writing-skills/SKILL.md`: Updated to distinguish when to create global vs project skills, added directory structure for both

## Architecture

**Two-tier system:**

1. **Project skills** (highest precedence)
   - Location: `.superpowers/skills/` in current directory
   - Purpose: Project-specific patterns and conventions
   - Shadows: Global skills with same path
   - Shared via: Version control (commit to project repo)

2. **Global skills** (base location)
   - Location: `~/.config/superpowers/skills/skills/` (aka `${SUPERPOWERS_SKILLS_ROOT}`)
   - Purpose: Personal library of skills
   - Synced from: upstream `obra/superpowers-skills`

## Additional Context

**Design decisions:**

- **`.superpowers/` directory**: Consistent with the skills plugin's naming convention
- **Current directory only**: Simple, predictable behavior without complex directory walking
- **Shadowing by skill path**: If the same skill path exists in both locations, project version wins
- **No configuration required**: Just create `.superpowers/skills/` and add skills

**Example use cases:**

1. **Team collaboration**: Commit `.superpowers/skills/` to version control so all team members use the same
project-specific techniques
```
   .superpowers/skills/
     deployment/
       deploy-to-staging/SKILL.md
     testing/
       project-test-setup/SKILL.md
```

2. **Project-specific TDD workflows**: Override global testing skills with project-specific test harness usage
```
   .superpowers/skills/
     testing/
       test-driven-development/SKILL.md  # Shadows global TDD skill
```

3. **Custom deployment skills**: Define deployment procedures specific to your project
```
   .superpowers/skills/
     deployment/
       release-checklist/SKILL.md
       hotfix-procedure/SKILL.md
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced project-level skill locations that take precedence over global skills.
  * Skills search and execution now check project-local directory first, then fall back to global.

* **Documentation**
  * Updated guides to clarify global vs. project skill organization and shadowing behavior.
  * Added skill location section detailing precedence order and directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->