### PR TITLE
Remove vestigial personal/core skills distinction

### DIFF
--- a/skills/using-skills/SKILL.md
+++ b/skills/using-skills/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: Getting Started with Skills
-description: Skills wiki intro - mandatory workflows, search tool, brainstorming triggers, personal skills
+description: Skills wiki intro - mandatory workflows, search tool, brainstorming triggers
 when_to_use: Read this FIRST at start of each conversation when skills are active
-version: 4.0.0
+version: 4.0.1
 ---
 
 # Getting Started with Skills

--- a/skills/using-skills/find-skills
+++ b/skills/using-skills/find-skills
@@ -1,19 +1,15 @@
 #!/usr/bin/env bash
 # find-skills - Find and list skills with descriptions
 # Shows all skills by default, filters by pattern if provided
-# Searches personal superpowers first, then core (personal shadows core)
 
 set -euo pipefail
 
 # Determine directories
-PERSONAL_SUPERPOWERS_DIR="${PERSONAL_SUPERPOWERS_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/superpowers}"
-PERSONAL_SKILLS_DIR="${PERSONAL_SUPERPOWERS_DIR}/skills"
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SKILLS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-CORE_SKILLS_DIR="${SKILLS_ROOT}"
+SKILLS_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-LOG_FILE="${PERSONAL_SUPERPOWERS_DIR}/search-log.jsonl"
+SUPERPOWERS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/superpowers"
+LOG_FILE="${SUPERPOWERS_DIR}/search-log.jsonl"
 
 # Show help
 if [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]]; then
@@ -33,13 +29,10 @@ EXAMPLES:
 OUTPUT:
   Each line shows: skill-path/SKILL.md - description
   Paths include /SKILL.md for direct use with Read tool
-  Personal skills listed first, then core skills
-  Personal skills shadow core skills when paths match
 
 SEARCH:
   Searches both skill content AND path names.
-  Personal skills at: ~/.config/superpowers/skills/
-  Core skills at: plugin installation directory
+  Skills location: ~/.config/superpowers/skills/
 EOF
     exit 0
 fi
@@ -61,8 +54,7 @@ get_skill_path() {
     echo "$rel_path"
 }
 
-# Collect all matching skills (use simple list for bash 3.2 compatibility)
-seen_skills_list=""
+# Collect all matching skills
 results=()
 
 # If pattern provided, log the search
@@ -71,51 +63,23 @@ if [[ -n "$PATTERN" ]]; then
     echo "{\"timestamp\":\"$timestamp\",\"query\":\"$PATTERN\"}" >> "$LOG_FILE" 2>/dev/null || true
 fi
 
-# Search personal skills first
-if [[ -d "$PERSONAL_SKILLS_DIR" ]]; then
-    while IFS= read -r file; do
-        [[ -z "$file" ]] && continue
-
-        skill_path=$(get_skill_path "$file" "$PERSONAL_SKILLS_DIR")
-        description=$(get_description "$file")
-
-        seen_skills_list="${seen_skills_list}${skill_path}"$'\n'
-        results+=("$skill_path|$description")
-    done < <(
-        if [[ -n "$PATTERN" ]]; then
-            # Pattern mode: search content and paths
-            {
-                grep -E -r "$PATTERN" "$PERSONAL_SKILLS_DIR/" --include="SKILL.md" -l 2>/dev/null || true
-                find "$PERSONAL_SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null | grep -E "$PATTERN" 2>/dev/null || true
-            } | sort -u
-        else
-            # Show all
-            find "$PERSONAL_SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null || true
-        fi
-    )
-fi
-
-# Search core skills (only if not shadowed)
+# Search skills directory
 while IFS= read -r file; do
     [[ -z "$file" ]] && continue
 
-    skill_path=$(get_skill_path "$file" "$CORE_SKILLS_DIR")
-
-    # Skip if shadowed by personal skill
-    echo "$seen_skills_list" | grep -q "^${skill_path}$" && continue
-
+    skill_path=$(get_skill_path "$file" "$SKILLS_DIR")
     description=$(get_description "$file")
     results+=("$skill_path|$description")
 done < <(
     if [[ -n "$PATTERN" ]]; then
         # Pattern mode: search content and paths
         {
-            grep -E -r "$PATTERN" "$CORE_SKILLS_DIR/" --include="SKILL.md" -l 2>/dev/null || true
-            find "$CORE_SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null | grep -E "$PATTERN" 2>/dev/null || true
+            grep -E -r "$PATTERN" "$SKILLS_DIR/" --include="SKILL.md" -l 2>/dev/null || true
+            find "$SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null | grep -E "$PATTERN" 2>/dev/null || true
         } | sort -u
     else
         # Show all
-        find "$CORE_SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null || true
+        find "$SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null || true
     fi
 )
 

--- a/skills/using-skills/skill-run
+++ b/skills/using-skills/skill-run
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Generic runner for skill scripts
-# Searches personal superpowers first, then core plugin
 #
 # Usage: scripts/skill-run <skill-relative-path> [args...]
 # Example: scripts/skill-run skills/collaboration/remembering-conversations/tool/search-conversations "query"
@@ -11,15 +10,14 @@ if [[ $# -eq 0 ]]; then
     cat <<'EOF'
 Usage: scripts/skill-run <skill-relative-path> [args...]
 
-Runs scripts from skills, checking personal superpowers first, then core.
+Runs scripts from skills directory.
 
 Examples:
   scripts/skill-run skills/collaboration/remembering-conversations/tool/search-conversations "query"
   scripts/skill-run skills/collaboration/remembering-conversations/tool/index-conversations --cleanup
 
 The script will be found at:
-  1. ~/.config/superpowers/<skill-relative-path> (personal, if exists)
-  2. ${SUPERPOWERS_SKILLS_ROOT}/<skill-relative-path> (core skills repository)
+  ${SUPERPOWERS_SKILLS_ROOT}/<skill-relative-path>
 EOF
     exit 1
 fi
@@ -29,26 +27,18 @@ SCRIPT_PATH="$1"
 shift  # Remove script path from args, leaving remaining args
 
 # Determine directories
-PERSONAL_SUPERPOWERS_DIR="${PERSONAL_SUPERPOWERS_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/superpowers}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILLS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Try personal superpowers first
-PERSONAL_SCRIPT="${PERSONAL_SUPERPOWERS_DIR}/${SCRIPT_PATH}"
-if [[ -x "$PERSONAL_SCRIPT" ]]; then
-    exec "$PERSONAL_SCRIPT" "$@"
-fi
-
-# Fall back to core plugin
-CORE_SCRIPT="${PLUGIN_ROOT}/${SCRIPT_PATH}"
-if [[ -x "$CORE_SCRIPT" ]]; then
-    exec "$CORE_SCRIPT" "$@"
+# Try to run the script
+SCRIPT="${SKILLS_ROOT}/${SCRIPT_PATH}"
+if [[ -x "$SCRIPT" ]]; then
+    exec "$SCRIPT" "$@"
 fi
 
 # Not found
 echo "Error: Script not found: $SCRIPT_PATH" >&2
 echo "" >&2
 echo "Searched:" >&2
-echo "  $PERSONAL_SCRIPT (personal)" >&2
-echo "  $CORE_SCRIPT (core)" >&2
+echo "  $SCRIPT" >&2
 exit 1


### PR DESCRIPTION
## Summary

- Removes non-functional "personal vs core" skills architecture
- Both variables (PERSONAL_SKILLS_DIR and CORE_SKILLS_DIR) resolved to the same path
- Simplifies find-skills and skill-run scripts
- Updates documentation to reflect actual behavior

## Background

The code claimed to support two skill locations:
- "Personal skills" at `~/.config/superpowers/skills`
- "Core skills" at plugin installation directory

However, both variables resolved to `~/.config/superpowers/skills` because the scripts run from within the cloned repo. The "personal shadows core" logic never actually worked since both paths were identical.

This appears to be vestigial code from an earlier architecture where skills were bundled with the plugin.

## Changes

- **find-skills**: Simplified to use single `SKILLS_DIR`, removed shadowing logic
- **skill-run**: Simplified to use single `SKILLS_ROOT`
- **SKILL.md**: Updated description, bumped version to 4.0.1
- **Documentation**: Updated help text to reflect actual single-location behavior

## Test Plan

- ✅ Verified find-skills lists all skills correctly
- ✅ Verified find-skills pattern matching works
- ✅ Verified skill-run shows correct help text
- ✅ No functionality changes - only removes non-functional code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified skills into a single directory; removed personal/core distinction.
  * Simplified search to a single pass over the unified directory; results remain sorted and show “path - description” when available.
  * Runner now resolves scripts only from the skills directory; streamlined error messages.
  * Logging now uses a central config location.

* **Documentation**
  * Updated help/usage text to reflect the unified skills location.
  * Shortened the frontmatter description and bumped the version to 4.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->