### PR TITLE
Fix skill-run path resolution to match find-skills

### DIFF
--- a/skills/using-skills/skill-run
+++ b/skills/using-skills/skill-run
@@ -28,7 +28,7 @@ shift  # Remove script path from args, leaving remaining args
 
 # Determine directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SKILLS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILLS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Try to run the script
 SCRIPT="${SKILLS_ROOT}/${SCRIPT_PATH}"


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug where `skill-run` was using incorrect path resolution, causing it to look in the wrong directory when deployed.

## Problem

`skill-run` was using one level of parent directory navigation (`..`) when it should use two levels (`../..`) like `find-skills` does.

When deployed to `~/.config/superpowers/skills`:
- Script location: `~/.config/superpowers/skills/skills/using-skills/skill-run`
- Old behavior: `SKILLS_ROOT` → `~/.config/superpowers/skills/skills/` ❌
- New behavior: `SKILLS_ROOT` → `~/.config/superpowers/skills/` ✓

## Changes

**skills/using-skills/skill-run:31**
```diff
-SKILLS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILLS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
```

This makes `skill-run` consistent with `find-skills`, which correctly uses `../..` to navigate from `skills/using-skills/` to the repository root.

## Test Plan

- ✅ Tested `skill-run` correctly resolves script paths
- ✅ Verified error messages show correct search path
- ✅ Confirmed consistency with `find-skills` path resolution
- ✅ Tested when deployed to `~/.config/superpowers/skills`

## Context

This bug existed before PR #8 but became apparent during testing of that PR. The issue was that `skill-run` and `find-skills` had different path resolution logic, causing `skill-run` to fail when actually deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected root directory detection for the skills runner, ensuring it reliably finds the project root when invoked from nested locations.
  * Improves consistency of path resolution, reducing missing file errors and mislocated resources during execution.
  * Enhances portability across environments and directories, leading to more predictable behavior when running skills from various entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->