### PR TITLE
Add project-specific skills with monorepo support

### DIFF
--- a/skills/meta/writing-skills/SKILL.md
+++ b/skills/meta/writing-skills/SKILL.md
@@ -12,7 +12,9 @@ languages: all
 
 **Writing skills IS Test-Driven Development applied to process documentation.**
 
-**Skills are written to `${SUPERPOWERS_SKILLS_ROOT}` (cloned to `~/.config/superpowers/skills/`).** You edit skills in your local branch of this repository.
+**Skills can be written to two locations:**
+- **Global skills**: `${SUPERPOWERS_SKILLS_ROOT}` (your working branch)
+- **Project skills**: `.claude/skills/` (version-controlled with project)
 
 You write test cases (pressure scenarios with subagents), watch them fail (baseline behavior), write the skill (documentation), watch tests pass (agents comply), and refactor (close loopholes).
 
@@ -47,16 +49,23 @@ The entire skill creation process follows RED-GREEN-REFACTOR.
 
 ## When to Create a Skill
 
-**Create when:**
+**Create global skill when:**
 - Technique wasn't intuitively obvious to you
 - You'd reference this again across projects
 - Pattern applies broadly (not project-specific)
-- Others would benefit
+- Others would benefit from it
 
-**Don't create for:**
+**Create project skill (`.claude/skills/`) when:**
+- Team-specific workflows and conventions
+- Project architecture patterns
+- Domain-specific best practices
+- Onboarding patterns for this codebase
+- Subproject-specific practices (in monorepos)
+
+**Don't create skill for:**
 - One-off solutions
 - Standard practices well-documented elsewhere
-- Project-specific conventions (put in CLAUDE.md)
+- Simple reminders (use CLAUDE.md instead)
 
 ## Skill Types
 
@@ -71,16 +80,31 @@ API docs, syntax guides, tool documentation (office docs)
 
 ## Directory Structure
 
-**All skills are in the skills repository at `${SUPERPOWERS_SKILLS_ROOT}`:**
+**Global skills** (in your branch at `${SUPERPOWERS_SKILLS_ROOT}`):
 
 ```
-${SUPERPOWERS_SKILLS_ROOT}
-  skill-name/
-    SKILL.md              # Main reference (required)
-    supporting-file.*     # Only if needed
+${SUPERPOWERS_SKILLS_ROOT}/
+  skills/
+    category/
+      skill-name/
+        SKILL.md              # Main reference (required)
+        supporting-file.*     # Only if needed
 ```
 
-**Flat namespace** - all skills in one searchable location
+**Project skills** (version-controlled with project):
+
+```
+.claude/
+  skills/
+    category/
+      skill-name/
+        SKILL.md              # Same structure as global
+        tool/                 # Executable scripts if needed
+```
+
+**Key differences:**
+- Global skills: Broadly applicable, personal working branch
+- Project skills: Team-shared, version-controlled, shadow global when paths match
 
 **Separate files for:**
 1. **Heavy reference** (100+ lines) - API docs, comprehensive syntax

--- a/skills/using-skills/SKILL.md
+++ b/skills/using-skills/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: Getting Started with Skills
-description: Skills wiki intro - mandatory workflows, search tool, brainstorming triggers
+description: Skills wiki intro - mandatory workflows, search tool, brainstorming triggers, project skills
 when_to_use: when starting any conversation
-version: 4.0.2
+version: 4.1.0
 ---
 
 # Getting Started with Skills
@@ -89,6 +89,32 @@ Your human partner's specific instructions describe WHAT to do, not HOW.
 
 **Why:** Specific instructions mean clear requirements, which is when workflows matter MOST. Skipping process on "simple" tasks is how simple tasks become complex problems.
 
+## Project-Specific Skills
+
+Skills can be defined at two levels:
+
+1. **Project skills** - `.claude/skills/` anywhere between your current directory and git root (team-shared, version controlled)
+2. **Global skills** - `~/.config/superpowers/skills/` (your working branch)
+
+**Project skills shadow global skills.** If `.claude/skills/testing/my-test/SKILL.md` exists, it overrides the global skill at that path.
+
+**Monorepo support:** The system walks up from your current directory to the git root looking for `.claude/skills/`. This means:
+- In a monorepo, you can have project-specific skills at any level
+- Working in `/monorepo/project-a/` finds `/monorepo/project-a/.claude/skills/` first
+- If not found, checks `/monorepo/.claude/skills/` at the root
+- Uses the closest `.claude/skills/` to your current directory
+
+**When to use project skills:**
+- Document team-specific workflows
+- Capture project architecture patterns
+- Share domain knowledge with team members
+- Onboard new developers with project context
+- Define subproject-specific practices in monorepos
+
+**To create a project skill:**
+1. Create `.claude/skills/` in your project (or subproject) directory
+2. Add skills following the standard structure (see skills/meta/writing-skills/SKILL.md)
+3. Commit to version control - team gets the skills automatically
 ## Summary
 
 **Starting any task:**

--- a/skills/using-skills/find-skills
+++ b/skills/using-skills/find-skills
@@ -1,12 +1,43 @@
 #!/usr/bin/env bash
 # find-skills - Find and list skills with when_to_use guidance
 # Shows all skills by default, filters by pattern if provided
+# Searches project skills first (walks up to git root), then global skills
 
 set -euo pipefail
 
 # Determine directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILLS_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Project skills (walk up from current dir to git root collecting ALL .claude/skills)
+PROJECT_SKILLS_DIRS=()
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+    CURRENT_DIR=$(pwd)
+
+    # Walk up from current directory to git root, collecting ALL .claude/skills directories
+    CHECK_DIR="$CURRENT_DIR"
+    while true; do
+        if [[ -d "$CHECK_DIR/.claude/skills" ]]; then
+            PROJECT_SKILLS_DIRS+=("$CHECK_DIR/.claude/skills")
+        fi
+
+        # Stop if we've reached git root
+        if [[ "$(cd "$CHECK_DIR" && pwd)" == "$(cd "$GIT_ROOT" && pwd)" ]]; then
+            break
+        fi
+
+        # Move up one directory
+        PARENT_DIR=$(dirname "$CHECK_DIR")
+
+        # Safety check: stop if we can't go up anymore
+        if [[ "$PARENT_DIR" == "$CHECK_DIR" ]]; then
+            break
+        fi
+
+        CHECK_DIR="$PARENT_DIR"
+    done
+fi
 
 SUPERPOWERS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/superpowers"
 LOG_FILE="${SUPERPOWERS_DIR}/search-log.jsonl"
@@ -29,10 +60,14 @@ EXAMPLES:
 OUTPUT:
   Each line shows: Use skill-path/SKILL.md when [trigger]
   Paths include /SKILL.md for direct use with Read tool
+  Project skills listed first, then global skills
+  Project skills shadow global skills when paths match
 
 SEARCH:
   Searches both skill content AND path names.
-  Skills location: ~/.config/superpowers/skills/
+  Project skills: Collects ALL .claude/skills/ from current dir to git root
+                  Closer skills shadow more distant ones when paths match
+  Global skills: ~/.config/superpowers/skills/
 EOF
     exit 0
 fi
@@ -54,7 +89,8 @@ get_skill_path() {
     echo "$rel_path"
 }
 
-# Collect all matching skills
+# Collect all matching skills (track seen skills to handle shadowing)
+seen_skills_list=""
 results=()
 
 # If pattern provided, log the search
@@ -63,23 +99,59 @@ if [[ -n "$PATTERN" ]]; then
     echo "{\"timestamp\":\"$timestamp\",\"query\":\"$PATTERN\"}" >> "$LOG_FILE" 2>/dev/null || true
 fi
 
-# Search skills directory
+# Search project skills (process closest first for proper shadowing)
+for PROJECT_SKILLS_DIR in "${PROJECT_SKILLS_DIRS[@]}"; do
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+
+        # Get path relative to .claude/skills/, then prepend "skills/" for consistency
+        # (project has .claude/skills/testing/foo/SKILL.md, output as skills/testing/foo/SKILL.md)
+        rel_path="${file#$PROJECT_SKILLS_DIR/}"
+        skill_path="skills/${rel_path}"
+
+        # Skip if already seen (shadowed by closer directory)
+        if echo "$seen_skills_list" | grep -q "^${skill_path}$"; then
+            continue
+        fi
+
+        when_to_use=$(get_when_to_use "$file")
+        seen_skills_list="${seen_skills_list}${skill_path}"$'\n'
+        results+=("$skill_path|$when_to_use")
+    done < <(
+        if [[ -n "$PATTERN" ]]; then
+            # Pattern mode: search content and paths
+            {
+                grep -E -r "$PATTERN" "$PROJECT_SKILLS_DIR/" --include="SKILL.md" -l 2>/dev/null || true
+                find "$PROJECT_SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null | grep -E "$PATTERN" 2>/dev/null || true
+            } | sort -u
+        else
+            # Show all
+            find "$PROJECT_SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null || true
+        fi
+    )
+done
+
+# Search global skills directory (skip if shadowed by project skills)
 while IFS= read -r file; do
     [[ -z "$file" ]] && continue
 
     skill_path=$(get_skill_path "$file" "$SKILLS_DIR")
+
+    # Skip if shadowed by project skill
+    echo "$seen_skills_list" | grep -q "^${skill_path}$" && continue
+
     when_to_use=$(get_when_to_use "$file")
     results+=("$skill_path|$when_to_use")
 done < <(
     if [[ -n "$PATTERN" ]]; then
-        # Pattern mode: search content and paths
+        # Pattern mode: search content and paths (exclude .claude directories)
         {
-            grep -E -r "$PATTERN" "$SKILLS_DIR/" --include="SKILL.md" -l 2>/dev/null || true
-            find "$SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null | grep -E "$PATTERN" 2>/dev/null || true
+            grep -E -r "$PATTERN" "$SKILLS_DIR/" --include="SKILL.md" --exclude-dir=".claude" -l 2>/dev/null || true
+            find "$SKILLS_DIR/" -name "SKILL.md" -type f -not -path "*/.claude/*" 2>/dev/null | grep -E "$PATTERN" 2>/dev/null || true
         } | sort -u
     else
-        # Show all
-        find "$SKILLS_DIR/" -name "SKILL.md" -type f 2>/dev/null || true
+        # Show all (exclude .claude directories)
+        find "$SKILLS_DIR/" -name "SKILL.md" -type f -not -path "*/.claude/*" 2>/dev/null || true
     fi
 )
 

--- a/skills/using-skills/skill-run
+++ b/skills/using-skills/skill-run
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Generic runner for skill scripts
+# Searches project skills first (walks up to git root), then global skills
 #
 # Usage: scripts/skill-run <skill-relative-path> [args...]
 # Example: scripts/skill-run skills/collaboration/remembering-conversations/tool/search-conversations "query"
@@ -10,14 +11,15 @@ if [[ $# -eq 0 ]]; then
     cat <<'EOF'
 Usage: scripts/skill-run <skill-relative-path> [args...]
 
-Runs scripts from skills directory.
+Runs scripts from skills, checking project first (walks up to git root), then global.
 
 Examples:
   scripts/skill-run skills/collaboration/remembering-conversations/tool/search-conversations "query"
   scripts/skill-run skills/collaboration/remembering-conversations/tool/index-conversations --cleanup
 
 The script will be found at:
-  ${SUPERPOWERS_SKILLS_ROOT}/<skill-relative-path>
+  1. .claude/<skill-relative-path> (walks up from current dir to git root)
+  2. ${SUPERPOWERS_SKILLS_ROOT}/<skill-relative-path> (global skills)
 EOF
     exit 1
 fi
@@ -30,7 +32,39 @@ shift  # Remove script path from args, leaving remaining args
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILLS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# Try to run the script
+# Project skills (walk up from current dir to git root looking for .claude/skills)
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+    CURRENT_DIR=$(pwd)
+
+    # Strip "skills/" prefix from SCRIPT_PATH for project lookup
+    # (user passes "skills/foo/bar", project should have ".claude/foo/bar")
+    PROJECT_SCRIPT_PATH="${SCRIPT_PATH#skills/}"
+
+    # Walk up from current directory to git root
+    CHECK_DIR="$CURRENT_DIR"
+    while true; do
+        PROJECT_SCRIPT="$CHECK_DIR/.claude/${PROJECT_SCRIPT_PATH}"
+        if [[ -x "$PROJECT_SCRIPT" ]]; then
+            exec "$PROJECT_SCRIPT" "$@"
+        fi
+
+        # Stop if we've reached git root
+        if [[ "$CHECK_DIR" == "$GIT_ROOT" ]]; then
+            break
+        fi
+
+        # Move up one directory
+        CHECK_DIR=$(dirname "$CHECK_DIR")
+
+        # Safety check: don't go above git root
+        if [[ ! "$CHECK_DIR" == "$GIT_ROOT"* ]]; then
+            break
+        fi
+    done
+fi
+
+# Try global skills
 SCRIPT="${SKILLS_ROOT}/${SCRIPT_PATH}"
 if [[ -x "$SCRIPT" ]]; then
     exec "$SCRIPT" "$@"
@@ -40,5 +74,21 @@ fi
 echo "Error: Script not found: $SCRIPT_PATH" >&2
 echo "" >&2
 echo "Searched:" >&2
-echo "  $SCRIPT" >&2
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+    CURRENT_DIR=$(pwd)
+    CHECK_DIR="$CURRENT_DIR"
+    PROJECT_SCRIPT_PATH="${SCRIPT_PATH#skills/}"
+    while true; do
+        echo "  $CHECK_DIR/.claude/${PROJECT_SCRIPT_PATH} (project)" >&2
+        if [[ "$CHECK_DIR" == "$GIT_ROOT" ]]; then
+            break
+        fi
+        CHECK_DIR=$(dirname "$CHECK_DIR")
+        if [[ ! "$CHECK_DIR" == "$GIT_ROOT"* ]]; then
+            break
+        fi
+    done
+fi
+echo "  $SCRIPT (global)" >&2
 exit 1


### PR DESCRIPTION
## Summary

Adds support for project-specific skills that can be version-controlled in `.claude/skills/` directories within projects. Includes full monorepo support with skill shadowing.

## Key Features

- **Project-specific skills**: Teams can version-control skills in `.claude/skills/` alongside code
- **Monorepo support**: Walks up from current directory to git root, collecting ALL `.claude/skills/` directories
- **Skill shadowing**: Closer skills override more distant ones when paths match
- **Backwards compatible**: Existing global skills continue to work unchanged

## Changes

### `skills/using-skills/find-skills`
- Collects ALL `.claude/skills/` directories from current location up to git root
- Implements shadowing logic (closer skills shadow more distant ones)
- Handles symlinks properly (e.g., `/tmp` → `/private/tmp`)
- Excludes `.claude/` directories from global skills search
- Compatible with upstream's `when_to_use` display format

### `skills/using-skills/skill-run`
- Searches project skills first (walks up to git root)
- Falls back to global skills if not found in project
- Strips "skills/" prefix when looking in `.claude/` directories
- Maintains consistent path format for user experience

### `skills/using-skills/SKILL.md`
- Documents project-specific skills feature
- Explains monorepo behavior
- Provides use cases and setup instructions
- Version bumped to 4.1.0

### `skills/meta/writing-skills/SKILL.md`
- Documents when to create global vs project skills
- Explains directory structure for both types
- Provides guidance on team-shared vs personal skills

## Example Structure

```
monorepo/
  .claude/skills/              # Root-level shared skills
    testing/shared-skill/      
  subproject-a/
    .claude/skills/            # Subproject-specific skills
      testing/shared-skill/    # Shadows root version
      testing/subproject-only/
    nested/
      .claude/skills/          # Deeply nested skills
        testing/shared-skill/  # Shadows both parent levels
```

## Test Plan

Tested with multi-level directory structure at `/tmp/test-project-skills`:
- ✅ Root skills visible from all subdirectories
- ✅ Subproject skills visible from subproject
- ✅ Nested skills override parent levels (shadowing works)
- ✅ Isolation between separate subprojects
- ✅ Symlink handling (macOS `/tmp` → `/private/tmp`)
- ✅ Global skills continue to work
- ✅ Compatible with upstream's `when_to_use` format

## Use Cases

- Document team-specific workflows
- Capture project architecture patterns
- Share domain knowledge with team members
- Onboard new developers with project context
- Define subproject-specific practices in monorepos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added project-scoped skills with automatic discovery from the current project up to the Git root.
  * Implemented shadowing so project skills override global skills; nearest project skills take precedence.
  * Updated skill execution to search project locations first, then fall back to global.
  * Improved search and listing to reflect project-first order and deduplicate shadowed entries.

* Documentation
  * Expanded guidance on global vs. project skills, including directory structure, governance, and when to create each.
  * Added examples and workflows for monorepos and shadowing behavior.
  * Updated descriptions and usage notes to align with the two-location model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->