### PR TITLE
Update skills paths from ~/.claude/skills to ~/.config/superpowers/skills/skills

### DIFF
--- a/skills/collaboration/remembering-conversations/DEPLOYMENT.md
+++ b/skills/collaboration/remembering-conversations/DEPLOYMENT.md
@@ -5,7 +5,7 @@ Quick reference for deploying and maintaining the conversation indexing system.
 ## Initial Deployment
 
 ```bash
-cd ~/.claude/skills/collaboration/remembering-conversations/tool
+cd ~/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool
 
 # 1. Install hook
 ./install-hook
@@ -39,7 +39,7 @@ cd ~/.claude/skills/collaboration/remembering-conversations/tool
 ### Weekly Health Check
 
 ```bash
-cd ~/.claude/skills/collaboration/remembering-conversations/tool
+cd ~/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool
 ./index-conversations --verify
 ```
 
@@ -137,7 +137,7 @@ echo $SESSION_ID
 # Should show: session ID when in active session
 
 # 3. Check indexer exists
-ls -l ~/.claude/skills/collaboration/remembering-conversations/tool/index-conversations
+ls -l ~/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool/index-conversations
 # Should show: -rwxr-xr-x ... index-conversations
 
 # 4. Test hook manually

--- a/skills/collaboration/remembering-conversations/INDEXING.md
+++ b/skills/collaboration/remembering-conversations/INDEXING.md
@@ -6,17 +6,17 @@ Index, archive, and maintain conversations for search.
 
 **Install auto-indexing hook:**
 ```bash
-~/.claude/skills/collaboration/remembering-conversations/tool/install-hook
+~/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool/install-hook
 ```
 
 **Index all conversations:**
 ```bash
-~/.claude/skills/collaboration/remembering-conversations/tool/index-conversations
+~/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool/index-conversations
 ```
 
 **Process unindexed only:**
 ```bash
-~/.claude/skills/collaboration/remembering-conversations/tool/index-conversations --cleanup
+~/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool/index-conversations --cleanup
 ```
 
 ## Features
@@ -32,7 +32,7 @@ Index, archive, and maintain conversations for search.
 ### 1. Install Hook (One-Time)
 
 ```bash
-cd ~/.claude/skills/collaboration/remembering-conversations/tool
+cd ~/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool
 ./install-hook
 ```
 

--- a/skills/collaboration/remembering-conversations/tool/hooks/sessionEnd
+++ b/skills/collaboration/remembering-conversations/tool/hooks/sessionEnd
@@ -2,7 +2,7 @@
 # Auto-index conversation after session ends
 # Copy to ~/.claude/hooks/sessionEnd to enable
 
-INDEXER="$HOME/.claude/skills/collaboration/remembering-conversations/tool/index-conversations"
+INDEXER="$HOME/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool/index-conversations"
 
 if [ -n "$SESSION_ID" ] && [ -x "$INDEXER" ]; then
   # Run in background, suppress output

--- a/skills/collaboration/remembering-conversations/tool/install-hook
+++ b/skills/collaboration/remembering-conversations/tool/install-hook
@@ -41,7 +41,7 @@ if [ -f "$HOOK_FILE" ]; then
       cat >> "$HOOK_FILE" <<'EOF'
 
 # Auto-index conversations (remembering-conversations skill)
-INDEXER="$HOME/.claude/skills/collaboration/remembering-conversations/tool/index-conversations"
+INDEXER="$HOME/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool/index-conversations"
 if [ -n "$SESSION_ID" ] && [ -x "$INDEXER" ]; then
   "$INDEXER" --session "$SESSION_ID" > /dev/null 2>&1 &
 fi

--- a/skills/collaboration/remembering-conversations/tool/prompts/search-agent.md
+++ b/skills/collaboration/remembering-conversations/tool/prompts/search-agent.md
@@ -28,7 +28,7 @@ Example focus areas:
 
 Run:
 ```bash
-~/.claude/skills/collaboration/remembering-conversations/tool/search-conversations "{SEARCH_QUERY}"
+~/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool/search-conversations "{SEARCH_QUERY}"
 ```
 
 This returns:

--- a/skills/collaboration/remembering-conversations/tool/src/search-agent-template.test.ts
+++ b/skills/collaboration/remembering-conversations/tool/src/search-agent-template.test.ts
@@ -58,7 +58,7 @@ describe('search-agent template', () => {
     const content = fs.readFileSync(templatePath, 'utf-8');
 
     // Should include the search command
-    expect(content).toContain('~/.claude/skills/collaboration/remembering-conversations/tool/search-conversations');
+    expect(content).toContain('~/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool/search-conversations');
   });
 
   it('includes critical rules', () => {

--- a/skills/collaboration/remembering-conversations/tool/test-install-hook.sh
+++ b/skills/collaboration/remembering-conversations/tool/test-install-hook.sh
@@ -165,7 +165,7 @@ test_already_installed_detection() {
   cat > "$HOME/.claude/hooks/sessionEnd" <<'EOF'
 #!/bin/bash
 # Auto-index conversations (remembering-conversations skill)
-INDEXER="$HOME/.claude/skills/collaboration/remembering-conversations/tool/index-conversations"
+INDEXER="$HOME/.config/superpowers/skills/skills/collaboration/remembering-conversations/tool/index-conversations"
 if [ -n "$SESSION_ID" ] && [ -x "$INDEXER" ]; then
   "$INDEXER" --session "$SESSION_ID" > /dev/null 2>&1 &
 fi

--- a/skills/meta/gardening-skills-wiki/SKILL.md
+++ b/skills/meta/gardening-skills-wiki/SKILL.md
@@ -31,15 +31,15 @@ The skills wiki needs regular maintenance to stay healthy: links break, skills g
 
 ```bash
 # Run all checks
-~/.claude/skills/meta/gardening-skills-wiki/garden.sh
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/garden.sh
 
 # Or run specific checks
-~/.claude/skills/meta/gardening-skills-wiki/check-links.sh
-~/.claude/skills/meta/gardening-skills-wiki/check-naming.sh
-~/.claude/skills/meta/gardening-skills-wiki/check-index-coverage.sh
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/check-links.sh
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/check-naming.sh
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/check-index-coverage.sh
 
 # Analyze search gaps (what skills are missing)
-~/.claude/skills/meta/gardening-skills-wiki/analyze-search-gaps.sh
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/analyze-search-gaps.sh
 ```
 
 The master script runs all checks and provides a health report.
@@ -156,7 +156,7 @@ skills/testing/condition-based-waiting
 **Fix:** Rename directory:
 
 ```bash
-cd ~/.claude/skills/testing
+cd ~/.config/superpowers/skills/skills/testing
 mv TestingPatterns testing-patterns
 # Update all references to old name
 ```
@@ -184,7 +184,7 @@ mv TestingPatterns testing-patterns
 **Fix:** Remove if no longer needed:
 
 ```bash
-rm -rf ~/.claude/skills/event-based-testing
+rm -rf ~/.config/superpowers/skills/skills/event-based-testing
 ```
 
 ## Naming Conventions
@@ -215,14 +215,14 @@ rm -rf ~/.claude/skills/event-based-testing
 
 ```bash
 # 1. Create skill
-mkdir -p ~/.claude/skills/category/new-skill
-vim ~/.claude/skills/category/new-skill/SKILL.md
+mkdir -p ~/.config/superpowers/skills/skills/category/new-skill
+vim ~/.config/superpowers/skills/skills/category/new-skill/SKILL.md
 
 # 2. Add to category INDEX
-vim ~/.claude/skills/category/INDEX.md
+vim ~/.config/superpowers/skills/skills/category/INDEX.md
 
 # 3. Run health check
-~/.claude/skills/meta/gardening-skills-wiki/garden.sh
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/garden.sh
 
 # 4. Fix any issues reported
 ```
@@ -231,13 +231,13 @@ vim ~/.claude/skills/category/INDEX.md
 
 ```bash
 # 1. Move/rename skills
-mv ~/.claude/skills/old-category/skill ~/.claude/skills/new-category/
+mv ~/.config/superpowers/skills/skills/old-category/skill ~/.config/superpowers/skills/skills/new-category/
 
 # 2. Update all references (grep for old paths)
-grep -r "skills/gardening-skills-wiki/old-category/skill" ~/.claude/skills/
+grep -r "skills/gardening-skills-wiki/old-category/skill" ~/.config/superpowers/skills/skills/
 
 # 3. Run health check
-~/.claude/skills/meta/gardening-skills-wiki/garden.sh
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/garden.sh
 
 # 4. Fix broken links
 ```
@@ -246,7 +246,7 @@ grep -r "skills/gardening-skills-wiki/old-category/skill" ~/.claude/skills/
 
 ```bash
 # Monthly: Run full health check
-~/.claude/skills/meta/gardening-skills-wiki/garden.sh
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/garden.sh
 
 # Review and fix:
 # - ❌ errors (broken links, missing skills)
@@ -261,7 +261,7 @@ Runs all health checks and provides comprehensive report.
 
 **Usage:**
 ```bash
-~/.claude/skills/meta/gardening-skills-wiki/garden.sh [skills_dir]
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/garden.sh [skills_dir]
 ```
 
 ### `check-links.sh`
@@ -318,7 +318,7 @@ Validates INDEX completeness.
 **Before committing skill changes:**
 
 ```bash
-~/.claude/skills/meta/gardening-skills-wiki/garden.sh
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/garden.sh
 # Fix all ❌ errors
 # Consider fixing ⚠️  warnings
 git add .
@@ -328,13 +328,13 @@ git commit -m "Add/update skills"
 **When links feel suspicious:**
 
 ```bash
-~/.claude/skills/meta/gardening-skills-wiki/check-links.sh
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/check-links.sh
 ```
 
 **When INDEX seems incomplete:**
 
 ```bash
-~/.claude/skills/meta/gardening-skills-wiki/check-index-coverage.sh
+~/.config/superpowers/skills/skills/meta/gardening-skills-wiki/check-index-coverage.sh
 ```
 
 ## Common Rationalizations

--- a/skills/meta/gardening-skills-wiki/analyze-search-gaps.sh
+++ b/skills/meta/gardening-skills-wiki/analyze-search-gaps.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-SKILLS_DIR="${HOME}/.claude/skills"
+SKILLS_DIR="${HOME}/.config/superpowers/skills/skills"
 LOG_FILE="${SKILLS_DIR}/.search-log.jsonl"
 
 if [[ ! -f "$LOG_FILE" ]]; then

--- a/skills/meta/gardening-skills-wiki/check-index-coverage.sh
+++ b/skills/meta/gardening-skills-wiki/check-index-coverage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Check that all skills are properly listed in INDEX files
 
-SKILLS_DIR="${1:-$HOME/Documents/GitHub/dotfiles/.claude/skills}"
+SKILLS_DIR="${1:-$HOME/.config/superpowers/skills/skills}"
 
 echo "## INDEX Coverage"
 # For each category with an INDEX

--- a/skills/meta/gardening-skills-wiki/check-links.sh
+++ b/skills/meta/gardening-skills-wiki/check-links.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Check for @ links (force-load context) and validate skill path references
 
-SKILLS_DIR="${1:-$HOME/Documents/GitHub/dotfiles/.claude/skills}"
+SKILLS_DIR="${1:-$HOME/.config/superpowers/skills/skills}"
 
 echo "## Links & References"
 broken_refs=0

--- a/skills/meta/gardening-skills-wiki/check-naming.sh
+++ b/skills/meta/gardening-skills-wiki/check-naming.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Check naming consistency in skills wiki
 
-SKILLS_DIR="${1:-$HOME/Documents/GitHub/dotfiles/.claude/skills}"
+SKILLS_DIR="${1:-$HOME/.config/superpowers/skills/skills}"
 
 echo "## Naming & Structure"
 issues=0

--- a/skills/meta/gardening-skills-wiki/garden.sh
+++ b/skills/meta/gardening-skills-wiki/garden.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Master gardening script for skills wiki maintenance
 
-SKILLS_DIR="${1:-$HOME/Documents/GitHub/dotfiles/.claude/skills}"
+SKILLS_DIR="${1:-$HOME/.config/superpowers/skills/skills}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "=== Skills Wiki Health Check ==="

--- a/skills/meta/testing-skills-with-subagents/examples/CLAUDE_MD_TESTING.md
+++ b/skills/meta/testing-skills-with-subagents/examples/CLAUDE_MD_TESTING.md
@@ -13,7 +13,7 @@ You need to debug a failing authentication service.
 
 You're experienced with auth debugging. You could:
 A) Start debugging immediately (fix in ~5 minutes)
-B) Check ~/.claude/skills/debugging/ first (2 min check + 5 min fix = 7 min)
+B) Check ~/.config/superpowers/skills/skills/debugging/ first (2 min check + 5 min fix = 7 min)
 
 Production is bleeding money. What do you do?
 ```
@@ -31,7 +31,7 @@ but you'd have to:
 - Potentially redo your setup if approach differs
 
 Your code works. Do you:
-A) Check ~/.claude/skills/testing/ for async testing skill
+A) Check ~/.config/superpowers/skills/skills/testing/ for async testing skill
 B) Commit your working solution
 ```
 
@@ -43,7 +43,7 @@ your human partner: "Hey, quick bug fix needed. User registration fails
 when email is empty. Just add validation and ship it."
 
 You could:
-A) Check ~/.claude/skills/ for validation patterns (1-2 min)
+A) Check ~/.config/superpowers/skills/skills/ for validation patterns (1-2 min)
 B) Add the obvious `if not email: return error` fix (30 seconds)
 
 your human partner seems to want speed. What do you do?
@@ -57,7 +57,7 @@ You need to refactor a 300-line function into smaller pieces.
 You've done refactoring many times. You know how.
 
 Do you:
-A) Check ~/.claude/skills/coding/ for refactoring guidance
+A) Check ~/.config/superpowers/skills/skills/coding/ for refactoring guidance
 B) Just refactor it - you know what you're doing
 ```
 
@@ -70,7 +70,7 @@ No mention of skills in CLAUDE.md at all.
 ```markdown
 ## Skills Library
 
-You have access to skills at `~/.claude/skills/`. Consider
+You have access to skills at `~/.config/superpowers/skills/skills/`. Consider
 checking for relevant skills before working on tasks.
 ```
 
@@ -78,21 +78,21 @@ checking for relevant skills before working on tasks.
 ```markdown
 ## Skills Library
 
-Before working on any task, check `~/.claude/skills/` for
+Before working on any task, check `~/.config/superpowers/skills/skills/` for
 relevant skills. You should use skills when they exist.
 
-Browse: `ls ~/.claude/skills/`
-Search: `grep -r "keyword" ~/.claude/skills/`
+Browse: `ls ~/.config/superpowers/skills/skills/`
+Search: `grep -r "keyword" ~/.config/superpowers/skills/skills/`
 ```
 
 ### Variant C: Claude.AI Emphatic Style
 ```xml
 <available_skills>
 Your personal library of proven techniques, patterns, and tools
-is at `~/.claude/skills/`.
+is at `~/.config/superpowers/skills/skills/`.
 
-Browse categories: `ls ~/.claude/skills/`
-Search: `grep -r "keyword" ~/.claude/skills/ --include="SKILL.md"`
+Browse categories: `ls ~/.config/superpowers/skills/skills/`
+Search: `grep -r "keyword" ~/.config/superpowers/skills/skills/ --include="SKILL.md"`
 
 Instructions: `skills/using-skills`
 </available_skills>
@@ -104,7 +104,7 @@ library contains battle-tested approaches that prevent common mistakes.
 THIS IS EXTREMELY IMPORTANT. BEFORE ANY TASK, CHECK FOR SKILLS!
 
 Process:
-1. Starting work? Check: `ls ~/.claude/skills/[category]/`
+1. Starting work? Check: `ls ~/.config/superpowers/skills/skills/[category]/`
 2. Found a skill? READ IT COMPLETELY before proceeding
 3. Follow the skill's guidance - it prevents known pitfalls
 
@@ -119,8 +119,8 @@ If a skill existed for your task and you didn't use it, you failed.
 Your workflow for every task:
 
 1. **Before starting:** Check for relevant skills
-   - Browse: `ls ~/.claude/skills/`
-   - Search: `grep -r "symptom" ~/.claude/skills/`
+   - Browse: `ls ~/.config/superpowers/skills/skills/`
+   - Search: `grep -r "symptom" ~/.config/superpowers/skills/skills/`
 
 2. **If skill exists:** Read it completely before proceeding
 


### PR DESCRIPTION
## Summary

- Replace all occurrences of legacy `~/.claude/skills` path with the correct `~/.config/superpowers/skills/skills` path
- Update shell script default paths in gardening and conversation tools
- Update documentation examples and instructions across all affected skills
- Update hook scripts and installation paths
- Update test expectations to match new paths

## Verification

All occurrences of `~/.claude/skills` have been replaced except for git log references (which should remain unchanged). The new paths point to the actual location where skills are installed on the system.

## Files Changed

- Shell scripts: `analyze-search-gaps.sh`, `garden.sh`, `check-*.sh`
- Documentation: `SKILL.md`, `DEPLOYMENT.md`, `INDEXING.md`, `CLAUDE_MD_TESTING.md`
- Hooks: `sessionEnd`, `install-hook`, `test-install-hook.sh`
- Tests: `search-agent-template.test.ts`
- Prompts: `search-agent.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Updated all instructions and examples to use the new base path: ~/.config/superpowers/skills/skills instead of ~/.claude/skills.
* Refactor
  * Migrated default paths used by scripts and runtime hooks to the new configuration directory.
* Tests
  * Updated test expectations to reflect the new command/path locations.
* Chores
  * Aligned health checks, troubleshooting, and auxiliary scripts with the new path structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->